### PR TITLE
[CS2113T-F11-2]-omupenguin-B-ViewSchedules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ src/main/resources/docs/
 .DS_Store
 *.iml
 bin/
+/data
+/data
+/text-ui-test/ACTUAL.TXT
+/text-ui-test/data/duke.txt

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -3,6 +3,7 @@ package duke;
 import duke.command.*;
 import duke.task.TaskList;
 
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -57,6 +58,19 @@ public class Parser {
                 }
             case "find":
                 return new FindStringCommand(inputLine);
+            case "view":
+                try {
+                    return new ViewScheduleCommand(inputArray[1]);
+                } catch (IndexOutOfBoundsException e) {
+                    ArrayList<String> msg = new ArrayList<String>(Arrays.asList(
+                            "Please use the format 'view today' or 'view <date>'!"
+                    ));
+                    Ui.printMsg(msg);
+                    break;
+                } catch (DateTimeParseException e) {
+                    Ui.printDateFormatError();
+                    break;
+                }
             default:
                 return addToList(command, inputLine);
         }

--- a/src/main/java/duke/Storage.java
+++ b/src/main/java/duke/Storage.java
@@ -56,9 +56,9 @@ public class Storage {
                 if (type.equals("T")) {
                     newTask = new ToDo(inArray[2]);
                 } else if (type.equals("E")) {
-                    newTask = new Event(inArray[2], Time.readTime(inArray[3])); //TODO: Update readTime
+                    newTask = new Event(inArray[2], Time.readDateTime(inArray[3])); //TODO: Update readTime
                 } else if (type.equals("D")) {
-                    newTask = new Deadline(inArray[2], Time.readTime(inArray[3]));
+                    newTask = new Deadline(inArray[2], Time.readDateTime(inArray[3]));
                 }
 
                 if (inArray[1].equals("1")) {

--- a/src/main/java/duke/Time.java
+++ b/src/main/java/duke/Time.java
@@ -1,5 +1,6 @@
 package duke;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
@@ -15,11 +16,16 @@ public class Time {
      * @param timeStr String that should be converted into DateTImeFormatter type.
      * @return A LocalDateTime variable that the computer can understand as time.
      */
-    public static LocalDateTime readTime(String timeStr) {
+    public static LocalDateTime readDateTime(String timeStr) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HHmm", Locale.ENGLISH);
             LocalDateTime time = LocalDateTime.parse(timeStr, formatter);
 //            System.out.println(time);
             return time;
+    }
 
+    public static LocalDate readDate (String timeStr) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH);
+        LocalDate time = LocalDate.parse(timeStr, formatter);
+        return time;
     }
 }

--- a/src/main/java/duke/Ui.java
+++ b/src/main/java/duke/Ui.java
@@ -57,4 +57,16 @@ public class Ui {
     public static void showLine() {
         System.out.println("    ____________________________________________________________");
     }
+
+    public static void printDateTimeFormatError() {
+        ArrayList<String> msg = new ArrayList<String>();
+        msg.add("Please use the format 'DD/MM/YYYY HHmm'!" );
+        Ui.printMsg(msg);
+    }
+
+    public static void printDateFormatError() {
+        ArrayList<String> msg = new ArrayList<String>();
+        msg.add("Please use the format 'DD/MM/YYYY'!" );
+        Ui.printMsg(msg);
+    }
 }

--- a/src/main/java/duke/command/AddCommand.java
+++ b/src/main/java/duke/command/AddCommand.java
@@ -43,7 +43,7 @@ public abstract class AddCommand extends Command{
     public boolean splitDescTime() {
         String[] data = taskDescription.split(dateTrigger + " "); // data[0] os description, data[1] is the time
         try {
-            time = Time.readTime(data[1]);
+            time = Time.readDateTime(data[1]);
             taskDescription = data[0];
             return true;
         } catch(ArrayIndexOutOfBoundsException e) {
@@ -52,9 +52,7 @@ public abstract class AddCommand extends Command{
             Ui.printMsg(msg);
             return false;
         }  catch(DateTimeParseException e) {
-            ArrayList<String> msg = new ArrayList<String>();
-            msg.add("Please use the format 'DD/MM/YYYY HHmm'!" );
-            Ui.printMsg(msg);
+            Ui.printDateTimeFormatError();
             return false;
         }
     }

--- a/src/main/java/duke/command/Command.java
+++ b/src/main/java/duke/command/Command.java
@@ -11,10 +11,10 @@ import java.util.ArrayList;
 public abstract class Command {
     /**
      * This method is called to read/write the specified duke.task.TaskList after every user input.
-     * @param task duke.task.TaskList containing all the tasks stored.
+     * @param tasks duke.task.TaskList containing all the tasks stored.
      * @throws Exception
      */
-    public abstract void execute(TaskList task) throws Exception;
+    public abstract void execute(TaskList tasks) throws Exception;
 
     /**
      * Returns an integer variable from the specified string.

--- a/src/main/java/duke/command/ViewScheduleCommand.java
+++ b/src/main/java/duke/command/ViewScheduleCommand.java
@@ -1,0 +1,46 @@
+package duke.command;
+
+import duke.Ui;
+import duke.task.Task;
+import duke.task.TaskList;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+
+import duke.Time;
+
+public class ViewScheduleCommand extends Command {
+
+    protected LocalDate viewDate;
+    protected String dateStr;
+
+    public ViewScheduleCommand(String dateStr) {
+        if (dateStr.equals("today")) {
+            viewDate = LocalDate.now();
+        } else {
+            this.viewDate = Time.readDate(dateStr);
+        }
+        this.dateStr = dateStr;
+    }
+
+    @Override
+    public void execute(TaskList tasks) {
+        ArrayList<String> msg = new ArrayList<String>();
+        ArrayList<Task> tasksOnGivenDate = new ArrayList<>();
+        for (int i = 0; i < tasks.size(); i++) {
+            Task currTask = tasks.getFromList(i);
+            //System.out.println(currTask.getDate().toLocalDate().compareTo(viewDate));
+            if (currTask.getDate().toLocalDate().compareTo(viewDate) == 0) {
+                tasksOnGivenDate.add(currTask);
+            }
+        }
+        tasksOnGivenDate.sort(Comparator.comparing(Task::getDate));
+
+        msg.add("Here is the schedule for " + dateStr + ":");
+        for (int i = 0; i < tasksOnGivenDate.size(); i++) {
+            msg.add((i+1) + "."  + tasksOnGivenDate.get(i).getTask());
+        }
+        Ui.printMsg(msg);
+
+    }
+}

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -7,8 +7,6 @@ import java.time.LocalDateTime;
  */
 public class Deadline extends Task {
 
-    protected LocalDateTime by;
-
     /**
      * Creates an instance with specified task description and due date.
      * @param description String of what the task entails.
@@ -17,7 +15,7 @@ public class Deadline extends Task {
     public Deadline(String description, LocalDateTime date) {
         super(description);
         type = 'D';
-        this.by = date;
+        this.date = date;
     }
 
     /**
@@ -26,8 +24,8 @@ public class Deadline extends Task {
      * @return string of when the task is due in the format '(by 11/11/1111 0000)'.
      */
     @Override
-    public String getDate () {
-        String byStr = timeToString(by);
+    public String getDateStr () {
+        String byStr = timeToString(date);
         return "(by: " + byStr + ")";
     }
 
@@ -38,7 +36,7 @@ public class Deadline extends Task {
      */
     @Override
     public String formatDateSave() {
-        String byStr = timeToString(by);
+        String byStr = timeToString(date);
         return " | " + byStr;
     }
 }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -7,8 +7,6 @@ import java.time.LocalDateTime;
  */
 public class Event extends Task {
 
-    protected LocalDateTime at;
-
     /**
      * Creates an instance with specified task description and due date.
      * @param description String of what the task entails.
@@ -17,7 +15,7 @@ public class Event extends Task {
     public Event(String description, LocalDateTime date) {
         super(description);
         type = 'E';
-        this.at = date;
+        this.date = date;
     }
 
     /**
@@ -26,8 +24,8 @@ public class Event extends Task {
      * @return string of when the task is due in the format '(at 11/11/1111 0000)'.
      */
     @Override
-    public String getDate() {
-        String atStr = timeToString(at);
+    public String getDateStr() {
+        String atStr = timeToString(date);
         return "(at: " + atStr + ")";
     }
 
@@ -38,7 +36,7 @@ public class Event extends Task {
      */
     @Override
     public String formatDateSave() {
-        String atStr = timeToString(at);
+        String atStr = timeToString(date);
         return " | " + atStr;
     }
 }

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -1,5 +1,7 @@
 package duke.task;
 
+import duke.Time;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
@@ -8,6 +10,7 @@ public class Task {
     protected String description;
     protected boolean isDone;
     protected char type;
+    protected LocalDateTime date = Time.readDateTime("01/01/0001 0000"); // Default date
 
     public Task(String description) {
         this.description = description;
@@ -27,8 +30,12 @@ public class Task {
         isDone = true;
     }
 
-    public String getDate() {
+    public String getDateStr() {
         return "";
+    }
+
+    public LocalDateTime getDate() {
+        return date;
     }
 
     public String timeToString(LocalDateTime time) {
@@ -38,7 +45,7 @@ public class Task {
     }
 
     public String getTask() {
-        return "[" + type + "][" + getStatusIcon() + "] " + description + getDate();
+        return "[" + type + "][" + getStatusIcon() + "] " + description + getDateStr();
     }
 
     public String formatDateSave() {


### PR DESCRIPTION
**NEW:**
- `ViewScheduleCommand` is used to view the schedule of tasks in a certain date using 'view [date]', where [date] is in the format 'DD/mm/YYYY'.

**CHANGES:**

- Error message for incorrect date format is also printed directly from `Ui`.
- Refactored code and added new method in `Time `to make it clear if the string being read is for `LocalTime `or `LocalDateTime`.
- Dates for tasks are now stored in `Command `rather than only in `Event `and `Deadline` to streamline the tasks.
- In `Task`: `getDate()` will now return the `LocalDateTime `variable, and `getDateStr `will return the message to be printed.